### PR TITLE
Update devcontainer.json for macos support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,8 @@
 {
     "image": "xianpengshen/clang-tools:18",
+    "runArgs": [
+        "--platform", "linux/amd64"
+    ],
     "customizations": {
         "vscode": {
             "extensions": [


### PR DESCRIPTION
dokcer image xianpengshen/clang-tools не поддерживает arm, надо зафорсить использовать linux/amd64 для работы дев контейнера из коробки на mac os